### PR TITLE
Handle destructive and lightning components

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ program
                     // ant migration tool requires the whole lightning bundle to be included, even if only
                     // one of the bundle components change.
                     if (parts[1] === 'aura') {
-                        var bundle = fs.readdirSync(parts[0]+'/'+parts[1]+'/'+parts[2]);
+                        const bundle = fs.readdirSync(parts[0]+'/'+parts[1]+'/'+parts[2]);
                         console.log('File was added or modified in a lightning bundle: %s', fileName);
                         bundle.forEach(function (fileName) {
                             fileListForCopy.push(parts[0]+'/'+parts[1]+'/'+parts[2]+'/'+fileName);

--- a/lib/metaUtils.js
+++ b/lib/metaUtils.js
@@ -62,7 +62,7 @@ var metaMap = {
 
 exports.packageWriter = function(metadata, apiVersion) {
 
-	apiVersion = apiVersion || '37.0';
+	apiVersion = apiVersion || '40.0';
 	var xml = xmlBuilder.create('Package', { version: '1.0'});
 		xml.att('xmlns', 'http://soap.sforce.com/2006/04/metadata');
 
@@ -86,7 +86,7 @@ exports.packageWriter = function(metadata, apiVersion) {
 	return xml.end({pretty: true});
 };
 
-exports.buildPackageDir = function (dirName, name, metadata, packgeXML, destructive, cb) {
+exports.buildPackageDir = function (dirName, name, metadata, packageXML, destructive, cb) {
 
 	var packageDir;
 	var packageFileName;
@@ -105,14 +105,21 @@ exports.buildPackageDir = function (dirName, name, metadata, packgeXML, destruct
 			return cb('Failed to write package directory ' + packageDir);
 		}
 
-		fs.writeFile(packageDir + packageFileName, packgeXML, 'utf8', (err) => {
+		fs.writeFile(packageDir + packageFileName, packageXML, 'utf8', (err) => {
 			if(err) {
 				return cb('Failed to write xml file');
 			}
+		});
+		// migration tool requires an empty package.xml for destructive changes
+		if (destructive) {
+			fs.writeFile(packageDir + '/package.xml', exports.packageWriter(null), 'utf8', (err) => {
+				if(err) {
+					return cb('Failed to write xml file');
+				}
 
 			return cb(null, packageDir);
-		});
-
+			});
+		}                    
 	});
 
 };
@@ -137,7 +144,7 @@ exports.copyFiles = function(sourceDir, buildDir, files) {
                     fs.accessSync(sourceDir + file + '-meta.xml', fs.F_OK);
                 }
                 catch (err) {
-                    console.log('does not exist');
+                    console.log(sourceDir + file + '-meta.xml does not exist');
                     metaExists = false;
                 }
 

--- a/lib/metaUtils.js
+++ b/lib/metaUtils.js
@@ -94,23 +94,23 @@ exports.buildPackageDir = function (dirName, name, metadata, packageXML, destruc
 
 	// @todo -- should probably validate this a bit
 	mkdirp(packageDir, (err) => {
-		if(err) {
+		if (err) {
 			return cb('Failed to write package directory ' + packageDir);
 		}
 
 		fs.writeFile(packageDir + packageFileName, packageXML, 'utf8', (err) => {
-			if(err) {
+			if (err) {
 				return cb('Failed to write xml file');
 			}
 		});
 		// migration tool requires an empty package.xml for destructive changes
 		if (destructive) {
 			fs.writeFile(packageDir + '/package.xml', exports.packageWriter(null), 'utf8', (err) => {
-				if(err) {
+				if (err) {
 					return cb('Failed to write xml file');
 				}
 
-			return cb(null, packageDir);
+				return cb(null, packageDir);
 			});
 		} else {
 			return cb(null, packageDir);

--- a/lib/metaUtils.js
+++ b/lib/metaUtils.js
@@ -119,7 +119,9 @@ exports.buildPackageDir = function (dirName, name, metadata, packageXML, destruc
 
 			return cb(null, packageDir);
 			});
-		}                    
+		} else {
+			return cb(null, packageDir);
+		}
 	});
 
 };

--- a/lib/metaUtils.js
+++ b/lib/metaUtils.js
@@ -36,7 +36,7 @@ var metaMap = {
 	'letterhead': 'Letterhead',
 	'managedTopics': 'ManagedTopics',
 	'matchingRules': 'MatchingRule',
-	'namedCredential': 'NamedCredential',
+	'namedCredentials': 'NamedCredential',
 	'networks': 'Network',
 	'objects': 'CustomObject',
 	'objectTranslations': 'CustomObjectTranslation',


### PR DESCRIPTION
We've had to perform manual steps when creating packages that are destructive or include Lightning Components:
- Per the [migration tool guide](https://developer.salesforce.com/docs/atlas.en-us.daas.meta/daas/daas_destructive_changes.htm), we have to include an empty package.xml in the same directory as destructiveChanges.xml
- As Bob Buzzard [documents](http://bobbuzzard.blogspot.com/2016/03/deploying-lightning-components-go-big.html), we have to include the entire Lightning Component bundle, even if only one file changes.

This change also updates the API version to 40 from 37, and handles file renaming in git version 2.14.2