### PR TITLE
Add support for lightning components

### DIFF
--- a/lib/metaUtils.js
+++ b/lib/metaUtils.js
@@ -1,86 +1,33 @@
-
-var xmlBuilder = require('xmlbuilder');
-var fs = require('fs-extra');
-var mkdirp = require('mkdirp');
-
-/**
- * Mapping of file name to Metadata Definition
- */
-//@todo -- finish out all the different metadata types
-var metaMap = {
-	'applications': 'CustomApplication',
-	'appMenus': 'AppMenu',
-	'approvalProcesses': 'ApprovalProcess',
-	'assignmentRules': 'AssignmentRules',
-	'aura': 'AuraDefinitionBundle',
-	'authproviders': 'AuthProvider',
-	'autoResponseRules': 'AutoResponseRules',
-	'classes': 'ApexClass',
-	'communities': 'Community',
-	'components': 'ApexComponent',
-	'connectedApps': 'ConnectedApp',
-	'customPermissions': 'CustomPermission',
-	'customMetadata': 'CustomMetadata',
-	'dashboards': 'Dashboard',
-	'documents': 'Document',
-	'email': 'EmailTemplate',
-	'escalationRules': 'EscalationRules',
-	'flowDefinitions': 'FlowDefinition',
-	'flows': 'Flow',
-	'groups': 'Group',
-	'homePageComponents': 'HomePageComponent',
-	'homePageLayouts': 'HomePageLayout',
-	'installedPackages': 'InstalledPackage',
-	'labels': 'CustomLabels',
-	'layouts': 'Layout',
-	'letterhead': 'Letterhead',
-	'managedTopics': 'ManagedTopics',
-	'matchingRules': 'MatchingRule',
-	'namedCredentials': 'NamedCredential',
-	'networks': 'Network',
-	'objects': 'CustomObject',
-	'objectTranslations': 'CustomObjectTranslation',
-	'pages': 'ApexPage',
-	'permissionsets': 'PermissionSet',
-	'profiles': 'Profile',
-	'queues': 'Queue',
-	'quickActions': 'QuickAction',
-	'remoteSiteSettings': 'RemoteSiteSetting',
-	'reports': 'Report',
-	'reportTypes': 'ReportType',
-	'roles': 'Role',
-	'staticresources': 'StaticResource',
-	'triggers': 'ApexTrigger',
-	'tabs': 'CustomTab',
-	'sharingRules': 'SharingRules',
-	'sharingSets': 'SharingSet',
-	'siteDotComSites': 'SiteDotCom',
-	'sites': 'CustomSite',
-	'workflows': 'Workflow',
-	'weblinks': 'CustomPageWebLink',
-};
-
 exports.packageWriter = function(metadata, apiVersion) {
 
 	apiVersion = apiVersion || '37.0';
 	var xml = xmlBuilder.create('Package', { version: '1.0'});
 		xml.att('xmlns', 'http://soap.sforce.com/2006/04/metadata');
+        for (var type in metadata) {
+            if (metadata.hasOwnProperty(type)) {
 
-	for (var type in metadata) {
+                var typeXml = xml.ele('types');
+                var auraDir = [];
 
-		if (metadata.hasOwnProperty(type)) {
+                metadata[type].forEach(function(item) {
 
-			var typeXml = xml.ele('types');
+                    if (type === 'aura') {
+                        auraDir.push(item.substr(0, item.search('/')));
+                    } else {
+                        typeXml.ele('members', item);
+                    }
 
+                });
 
-			metadata[type].forEach(function(item) {
-				typeXml.ele('members', item);
-			});
-
-			typeXml.ele('name', metaMap[type]);
-		}
-
-	}
+                var unique = Array.from(new Set(auraDir));
+                if (auraDir.length > 0) {
+                    for (i = 0; i < unique.length; i++) {
+                        typeXml.ele('members', unique[i]);
+                    }
+                }
+                typeXml.ele('name', metaMap[type]);
+            }
+        }
 	xml.ele('version', apiVersion);
 
 	return xml.end({pretty: true});
@@ -147,7 +94,12 @@ exports.copyFiles = function(sourceDir, buildDir, files) {
                 }
 
             }
-
+            if(file.indexOf('/aura/') != -1) {
+                var auraComponent = file.replace(/.*(\/aura\/.*)\/.+/g, "$1");
+                console.log('auraComponent: ' + auraComponent);
+                console.log(sourceDir + auraComponent +  ' --> ' + buildDir + auraComponent);
+                fs.copySync(sourceDir + 'src/' + auraComponent, buildDir + auraComponent, { recursive : true});
+            }
         }
 
     });


### PR DESCRIPTION
Fix package.xml creation for lightning components and copy the entire component when a change is detected.

The fix guess that source code is under a "src" directory, maybe the regexp replacement could be improved.